### PR TITLE
some improvements

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,9 +1,9 @@
 #![feature(test)]
 
 extern crate test;
-use test::{black_box, Bencher};
 use async_oneshot::*;
 use futures_lite::future::{block_on, join};
+use test::{black_box, Bencher};
 
 #[bench]
 fn create(b: &mut Bencher) {
@@ -34,16 +34,12 @@ fn create_send_recv(b: &mut Bencher) {
 fn create_wait_send_recv(b: &mut Bencher) {
     b.iter(|| {
         let (send, recv) = oneshot::<bool>();
-        black_box(
-            block_on(
-                join(
-                    async {
-                        let send = send.wait().await.unwrap();
-                        send.send(true).unwrap()
-                    },
-                    async { recv.await.unwrap() }
-                )
-            )
-        );
+        black_box(block_on(join(
+            async {
+                let send = send.wait().await.unwrap();
+                send.send(true).unwrap()
+            },
+            async { recv.await.unwrap() },
+        )));
     });
 }

--- a/src/inner.rs
+++ b/src/inner.rs
@@ -1,11 +1,11 @@
-use core::sync::atomic::AtomicUsize;
+use core::sync::atomic::AtomicU8;
 use core::sync::atomic::Ordering::{AcqRel, Acquire};
 use core::{cell::UnsafeCell, mem::MaybeUninit, ptr::drop_in_place, task::Waker};
 
 #[derive(Debug)]
 pub struct Inner<T> {
     // This one is easy.
-    state: AtomicUsize,
+    state: AtomicU8,
     // This is where it all starts to go a bit wrong.
     value: UnsafeCell<MaybeUninit<T>>,
     // Yes, these are subtly different from the last just to confuse you.
@@ -13,15 +13,15 @@ pub struct Inner<T> {
     recv: UnsafeCell<MaybeUninit<Waker>>,
 }
 
-const CLOSED: usize = 0b1000;
-const SEND: usize = 0b0100;
-const RECV: usize = 0b0010;
-const READY: usize = 0b0001;
+const CLOSED: u8 = 0b1000;
+const SEND: u8 = 0b0100;
+const RECV: u8 = 0b0010;
+const READY: u8 = 0b0001;
 
 impl<T> Inner<T> {
     pub fn new() -> Self {
         Inner {
-            state: AtomicUsize::new(0),
+            state: AtomicU8::new(0),
             value: UnsafeCell::new(MaybeUninit::uninit()),
             send: UnsafeCell::new(MaybeUninit::uninit()),
             recv: UnsafeCell::new(MaybeUninit::uninit()),
@@ -96,7 +96,7 @@ impl<T> Drop for Inner<T> {
 unsafe impl<T: Send> Send for Inner<T> {}
 unsafe impl<T: Sync> Sync for Inner<T> {}
 
-pub struct State(usize);
+pub struct State(u8);
 
 impl State {
     pub fn closed(&self) -> bool {

--- a/src/inner.rs
+++ b/src/inner.rs
@@ -102,6 +102,7 @@ impl<T> Drop for Inner<T> {
 unsafe impl<T: Send> Send for Inner<T> {}
 unsafe impl<T: Sync> Sync for Inner<T> {}
 
+#[derive(Clone, Copy)]
 pub struct State(u8);
 
 impl State {

--- a/src/inner.rs
+++ b/src/inner.rs
@@ -1,11 +1,6 @@
-use core::cell::UnsafeCell;
-use core::mem::MaybeUninit;
-use core::ptr::drop_in_place;
-use core::sync::atomic::{
-    AtomicUsize,
-    Ordering::{AcqRel, Acquire},
-};
-use core::task::Waker;
+use core::sync::atomic::AtomicUsize;
+use core::sync::atomic::Ordering::{AcqRel, Acquire};
+use core::{cell::UnsafeCell, mem::MaybeUninit, ptr::drop_in_place, task::Waker};
 
 #[derive(Debug)]
 pub struct Inner<T> {

--- a/src/inner.rs
+++ b/src/inner.rs
@@ -37,11 +37,13 @@ impl<T> Inner<T> {
     // it is set. This would be unsafe if it were public.
     pub fn recv(&self) -> &Waker {
         // MUST BE SET
+        debug_assert!(self.state().recv());
         unsafe { &*(*self.recv.get()).as_ptr() }
     }
 
     // Sets the receiver's waker.
     pub fn set_recv(&self, waker: Waker) -> State {
+        debug_assert!(!self.state().recv());
         let recv = self.recv.get();
         unsafe { (*recv).as_mut_ptr().write(waker) } // !
         State(self.state.fetch_or(RECV, AcqRel))
@@ -50,11 +52,13 @@ impl<T> Inner<T> {
     // Gets the sender's waker. You *must* check the state to ensure
     // it is set. This would be unsafe if it were public.
     pub fn send(&self) -> &Waker {
+        debug_assert!(self.state().send());
         unsafe { &*(*self.send.get()).as_ptr() }
     }
 
     // Sets the sender's waker.
     pub fn set_send(&self, waker: Waker) -> State {
+        debug_assert!(!self.state().send());
         let send = self.send.get();
         unsafe { (*send).as_mut_ptr().write(waker) } // !
         State(self.state.fetch_or(SEND, AcqRel))
@@ -62,10 +66,12 @@ impl<T> Inner<T> {
 
     pub fn take_value(&self) -> T {
         // MUST BE SET
+        debug_assert!(self.state().ready());
         unsafe { (*self.value.get()).as_ptr().read() }
     }
 
     pub fn set_value(&self, value: T) -> State {
+        debug_assert!(!self.state().ready());
         let val = self.value.get();
         unsafe { (*val).as_mut_ptr().write(value) }
         State(self.state.fetch_or(READY, AcqRel))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,4 +36,3 @@ pub enum TryRecvError<T> {
     /// The Sender has dropped.
     Closed,
 }
-

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -11,13 +11,12 @@ pub struct Receiver<T> {
 }
 
 impl<T> Receiver<T> {
-
     pub(crate) fn new(inner: Arc<Inner<T>>) -> Self {
         Receiver { inner, done: false }
     }
 
     /// Closes the channel by causing an immediate drop.
-    pub fn close(self) { }
+    pub fn close(self) {}
 
     /// Attempts to receive. On failure, if the channel is not closed,
     /// returns self to try again.
@@ -34,8 +33,6 @@ impl<T> Receiver<T> {
         }
     }
 }
-
-
 
 impl<T> Future for Receiver<T> {
     type Output = Result<T, Closed>;
@@ -54,9 +51,11 @@ impl<T> Future for Receiver<T> {
                 this.done = true;
                 Poll::Ready(Ok(this.inner.take_value()))
             } else {
-                if state.send() { this.inner.send().wake_by_ref(); }
+                if state.send() {
+                    this.inner.send().wake_by_ref();
+                }
                 Poll::Pending
-            }                
+            }
         }
     }
 }
@@ -67,7 +66,9 @@ impl<T> Drop for Receiver<T> {
             let state = self.inner.state();
             if !state.closed() && !state.ready() {
                 let old = self.inner.close();
-                if old.send() { self.inner.send().wake_by_ref(); }
+                if old.send() {
+                    self.inner.send().wake_by_ref();
+                }
             }
         }
     }

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -11,16 +11,17 @@ pub struct Sender<T> {
 }
 
 impl<T> Sender<T> {
-
     pub(crate) fn new(inner: Arc<Inner<T>>) -> Self {
         Sender { inner, done: false }
     }
-        
+
     /// Closes the channel by causing an immediate drop
-    pub fn close(self) { }
+    pub fn close(self) {}
 
     /// true if the channel is closed
-    pub fn is_closed(&self) -> bool { self.inner.state().closed() }
+    pub fn is_closed(&self) -> bool {
+        self.inner.state().closed()
+    }
 
     /// Waits for a Receiver to be waiting for us to send something
     /// (i.e. allows you to produce a value to send on demand).
@@ -39,7 +40,8 @@ impl<T> Sender<T> {
                 *this = Some(that);
                 Poll::Pending
             }
-        }).await
+        })
+        .await
     }
 
     /// Sends a message on the channel. Fails if the Receiver is dropped.
@@ -58,7 +60,7 @@ impl<T> Sender<T> {
             inner.take_value(); // force drop.
             Err(Closed())
         }
-    }        
+    }
 }
 
 impl<T> Drop for Sender<T> {
@@ -67,8 +69,10 @@ impl<T> Drop for Sender<T> {
             let state = self.inner.state();
             if !state.closed() {
                 let old = self.inner.close();
-                if old.recv() { self.inner.recv().wake_by_ref(); }
-            }            
+                if old.recv() {
+                    self.inner.recv().wake_by_ref();
+                }
+            }
         }
     }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -4,7 +4,7 @@ use futures_micro::prelude::*;
 
 #[test]
 fn send_recv() {
-    let (s,r) = oneshot::<i32>();
+    let (s, r) = oneshot::<i32>();
     assert_eq!(
         block_on(zip!(async { s.send(42).unwrap() }, r)),
         ((), Ok(42))
@@ -12,7 +12,7 @@ fn send_recv() {
 }
 #[test]
 fn recv_send() {
-    let (s,r) = oneshot::<i32>();
+    let (s, r) = oneshot::<i32>();
     assert_eq!(
         block_on(zip!(r, async { s.send(42).unwrap() })),
         (Ok(42), ())
@@ -21,71 +21,75 @@ fn recv_send() {
 
 #[test]
 fn close_recv() {
-    let (s,r) = oneshot::<i32>();
+    let (s, r) = oneshot::<i32>();
     s.close();
     assert_eq!(Err(Closed()), block_on(r));
 }
 
 #[test]
 fn close_send() {
-    let (s,r) = oneshot::<bool>();
+    let (s, r) = oneshot::<bool>();
     r.close();
     assert_eq!(Err(Closed()), s.send(true));
 }
 
 #[test]
 fn send_close() {
-    let (s,r) = oneshot::<bool>();
+    let (s, r) = oneshot::<bool>();
     s.send(true).unwrap();
     r.close();
 }
 
 #[test]
 fn recv_close() {
-    let (s,r) = oneshot::<bool>();
-    assert_eq!(
-        block_on(zip!(r, async { s.close() })),
-        (Err(Closed()), ())
-    )
+    let (s, r) = oneshot::<bool>();
+    assert_eq!(block_on(zip!(r, async { s.close() })), (Err(Closed()), ()))
 }
 
 #[test]
 fn wait_close() {
-    let (s,r) = oneshot::<bool>();
+    let (s, r) = oneshot::<bool>();
     assert_eq!(
-        block_on(
-            zip!(async { s.wait().await.unwrap_err() },
-                 async { r.close() })
-        ),
+        block_on(zip!(async { s.wait().await.unwrap_err() }, async {
+            r.close()
+        })),
         (Closed(), ())
     )
 }
 
 #[test]
 fn wait_recv_close() {
-    let (s,r) = oneshot::<bool>();
+    let (s, r) = oneshot::<bool>();
     assert_eq!(
-        block_on(
-            zip!(async { s.wait().await.unwrap().close(); println!("closed"); }, r)
-        ),
+        block_on(zip!(
+            async {
+                s.wait().await.unwrap().close();
+                println!("closed");
+            },
+            r
+        )),
         ((), Err(Closed()))
     )
 }
 
 #[test]
 fn wait_recv_send() {
-    let (s,r) = oneshot::<i32>();
+    let (s, r) = oneshot::<i32>();
     assert_eq!(
-        block_on(
-            zip!(async { let s = s.wait().await?; s.send(42) }, r)
-        ),
+        block_on(zip!(
+            async {
+                let s = s.wait().await?;
+                s.send(42)
+            },
+            r
+        )),
         (Ok(()), Ok(42))
     )
 }
 
 #[test]
 fn close_wait() {
-    let (s,r) = oneshot::<bool>();
+    let (s, r) = oneshot::<bool>();
     r.close();
     assert_eq!(Closed(), block_on(s.wait()).unwrap_err());
 }


### PR DESCRIPTION
I looked through the updated code and tried to improve it (again).

I've done:
* `cargo fmt`
* got rid of the `.done` struct field in both `Sender` (replaced with manual destructuring + `mem::forget`) and `Receiver` (replaced with `Option`)
* added debug assertions to `Inner`

I checked the resulting code (up to `a2a4205`) using `cargo clippy`, `cargo test` and `cargo miri test`, which all passed.