### PR TITLE
some safe improvements

### DIFF
--- a/src/inner.rs
+++ b/src/inner.rs
@@ -21,7 +21,6 @@ const RECV: usize   = 0b0010;
 const READY: usize  = 0b0001;
 
 impl<T> Inner<T> {
-
     pub fn new() -> Self {
         Inner {
             state: AtomicUsize::new(0),
@@ -73,7 +72,6 @@ impl<T> Inner<T> {
     pub fn close(&self) -> State {
         State(self.state.fetch_or(CLOSED, AcqRel))
     }
-
 }
 
 impl<T> Drop for Inner<T> {
@@ -95,13 +93,8 @@ unsafe impl<T: Sync> Sync for Inner<T> {}
 pub struct State(usize);
 
 impl State {
-
     pub fn closed(&self) -> bool { (self.0 & CLOSED) == CLOSED }
-
-    pub fn ready(&self)  -> bool { (self.0 & READY) == READY }
-
-    pub fn send(&self)   -> bool { (self.0 & SEND) == SEND }
-
-    pub fn recv(&self)   -> bool { (self.0 & RECV) == RECV }
-
+    pub fn ready(&self)  -> bool { (self.0 & READY ) == READY  }
+    pub fn send(&self)   -> bool { (self.0 & SEND  ) == SEND   }
+    pub fn recv(&self)   -> bool { (self.0 & RECV  ) == RECV   }
 }

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -1,6 +1,5 @@
 use crate::*;
-use core::future::Future;
-use core::pin::Pin;
+use core::{future::Future, pin::Pin};
 use core::task::{Context, Poll};
 
 /// The receiving half of a oneshot channel.

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -11,7 +11,6 @@ pub struct Receiver<T> {
 }
 
 impl<T> Receiver<T> {
-
     pub(crate) fn new(inner: Arc<Inner<T>>) -> Self {
         Receiver { inner, done: false }
     }
@@ -35,8 +34,6 @@ impl<T> Receiver<T> {
     }
 }
 
-
-
 impl<T> Future for Receiver<T> {
     type Output = Result<T, Closed>;
     fn poll(self: Pin<&mut Self>, ctx: &mut Context) -> Poll<Result<T, Closed>> {
@@ -56,7 +53,7 @@ impl<T> Future for Receiver<T> {
             } else {
                 if state.send() { this.inner.send().wake_by_ref(); }
                 Poll::Pending
-            }                
+            }
         }
     }
 }

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -1,6 +1,6 @@
 use crate::*;
 use alloc::sync::Arc;
-use core::task::Poll;
+use core::{future::Future, task::Poll};
 use futures_micro::poll_state;
 
 /// The sending half of a oneshot channel.
@@ -24,7 +24,7 @@ impl<T> Sender<T> {
     /// Waits for a Receiver to be waiting for us to send something
     /// (i.e. allows you to produce a value to send on demand).
     /// Fails if the Receiver is dropped.
-    pub async fn wait(self) -> Result<Self, Closed> {
+    pub fn wait(self) -> impl Future<Output = Result<Self, Closed>> {
         poll_state(Some(self), |this, ctx| {
             let mut that = this.take().unwrap();
             let state = that.inner.state();
@@ -38,7 +38,7 @@ impl<T> Sender<T> {
                 *this = Some(that);
                 Poll::Pending
             }
-        }).await
+        })
     }
 
     /// Sends a message on the channel. Fails if the Receiver is dropped.

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -11,11 +11,10 @@ pub struct Sender<T> {
 }
 
 impl<T> Sender<T> {
-
     pub(crate) fn new(inner: Arc<Inner<T>>) -> Self {
         Sender { inner, done: false }
     }
-        
+
     /// Closes the channel by causing an immediate drop
     pub fn close(self) { }
 
@@ -58,7 +57,7 @@ impl<T> Sender<T> {
             inner.take_value(); // force drop.
             Err(Closed())
         }
-    }        
+    }
 }
 
 impl<T> Drop for Sender<T> {
@@ -68,7 +67,7 @@ impl<T> Drop for Sender<T> {
             if !state.closed() {
                 let old = self.inner.close();
                 if old.recv() { self.inner.recv().wake_by_ref(); }
-            }            
+            }
         }
     }
 }


### PR DESCRIPTION
This PR contains the safe and beneficial parts of #6.

* some formatting corrections, but not as invasive as an `cargo fmt` run
* got rid of the `async fn`, as this has a noticable effect on output executable sizes and runtime performance.
* added debug assertions to `Inner`