### PR TITLE
fix race condition in Receiver::poll

### DIFF
--- a/src/inner.rs
+++ b/src/inner.rs
@@ -96,6 +96,7 @@ impl<T> Drop for Inner<T> {
 unsafe impl<T: Send> Send for Inner<T> {}
 unsafe impl<T: Sync> Sync for Inner<T> {}
 
+#[derive(Clone, Copy)]
 pub struct State(usize);
 
 impl State {

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -10,25 +10,36 @@ pub struct Receiver<T> {
 }
 
 impl<T> Receiver<T> {
+    #[inline]
     pub(crate) fn new(inner: Arc<Inner<T>>) -> Self {
         Receiver { inner, done: false }
     }
 
     /// Closes the channel by causing an immediate drop.
+    #[inline]
     pub fn close(self) { }
+
+    fn handle_state(&mut self, state: crate::inner::State) -> Poll<Result<T, Closed>> {
+        if state.ready() {
+            Poll::Ready(Ok(self.inner.take_value()))
+        } else if state.closed() {
+            Poll::Ready(Err(Closed()))
+        } else {
+            Poll::Pending
+        }.map(|x| {
+            self.done = true;
+            x
+        })
+    }
 
     /// Attempts to receive. On failure, if the channel is not closed,
     /// returns self to try again.
     pub fn try_recv(mut self) -> Result<T, TryRecvError<T>> {
         let state = self.inner.state();
-        if state.ready() {
-            self.done = true;
-            Ok(self.inner.take_value())
-        } else if state.closed() {
-            self.done = true;
-            Err(TryRecvError::Closed)
-        } else {
-            Err(TryRecvError::Empty(self))
+        match self.handle_state(state) {
+            Poll::Ready(Ok(x)) => Ok(x),
+            Poll::Ready(Err(Closed())) => Err(TryRecvError::Closed),
+            Poll::Pending => Err(TryRecvError::Empty(self)),
         }
     }
 }
@@ -37,23 +48,17 @@ impl<T> Future for Receiver<T> {
     type Output = Result<T, Closed>;
     fn poll(self: Pin<&mut Self>, ctx: &mut Context) -> Poll<Result<T, Closed>> {
         let this = Pin::into_inner(self);
-        let state = this.inner.state();
-        if state.ready() {
-            this.done = true;
-            Poll::Ready(Ok(this.inner.take_value()))
-        } else if state.closed() {
-            this.done = true;
-            Poll::Ready(Err(Closed()))
-        } else {
-            let state = this.inner.set_recv(ctx.waker().clone());
-            if state.ready() {
-                this.done = true;
-                Poll::Ready(Ok(this.inner.take_value()))
-            } else {
-                if state.send() { this.inner.send().wake_by_ref(); }
-                Poll::Pending
-            }
+        match this.handle_state(this.inner.state()) {
+            Poll::Pending => {},
+            x => return x,
         }
+        let state = this.inner.set_recv(ctx.waker().clone());
+        match this.handle_state(state) {
+            Poll::Pending => {},
+            x => return x,
+        }
+        if state.send() { this.inner.send().wake_by_ref(); }
+        Poll::Pending
     }
 }
 


### PR DESCRIPTION
Fixes #9.
I'm unsure if this PR does cause an performance regression.

NOTE: This PR was extracted from #6.
I think the only really debatable things are the `.map` call in `handle_state` and maybe bikeshedding of the `handle_state` method name.