### PR TITLE
[POC] attempt a proof-based approach to model the unsafety

### DIFF
--- a/benches/oneshot.rs
+++ b/benches/oneshot.rs
@@ -41,7 +41,7 @@ pub fn try_recv(c: &mut Criterion) {
                 send.send(1).unwrap();
                 recv
             },
-            |recv| recv.try_recv().unwrap(),
+            |mut recv| recv.try_recv().unwrap(),
             BatchSize::SmallInput
         )
     );
@@ -49,7 +49,7 @@ pub fn try_recv(c: &mut Criterion) {
         "empty",
         |b| b.iter_batched(
             || oneshot::<usize>(),
-            |(send, recv)| (recv.try_recv().unwrap_err(), send),
+            |(send, mut recv)| (recv.try_recv().unwrap_err(), send),
             BatchSize::SmallInput
         )
     );
@@ -57,7 +57,7 @@ pub fn try_recv(c: &mut Criterion) {
         "closed",
         |b| b.iter_batched(
             || oneshot::<usize>().1,
-            |recv| recv.try_recv().unwrap_err(),
+            |mut recv| recv.try_recv().unwrap_err(),
             BatchSize::SmallInput
         )
     );

--- a/src/inner.rs
+++ b/src/inner.rs
@@ -1,102 +1,129 @@
 use core::cell::UnsafeCell;
+#[cfg(not(debug_assertions))]
+use core::marker::PhantomData;
 use core::mem::MaybeUninit;
 use core::ptr::drop_in_place;
-use core::sync::atomic::{AtomicUsize, Ordering::{Acquire, AcqRel}};
+use core::sync::atomic::{AtomicU8, Ordering::{Acquire, AcqRel}};
 use core::task::Waker;
 
 #[derive(Debug)]
 pub(crate) struct Inner<T> {
     // This one is easy.
-    state: AtomicUsize,
+    state: AtomicU8,
     // This is where it all starts to go a bit wrong.
     value: UnsafeCell<MaybeUninit<T>>,
-    // Yes, these are subtly different from the last just to confuse you.
-    send: UnsafeCell<MaybeUninit<Waker>>,
-    recv: UnsafeCell<MaybeUninit<Waker>>,
+    sender:    UnsafeCell<MaybeUninit<Waker>>,
+    receiver:  UnsafeCell<MaybeUninit<Waker>>,
 }
 
-const CLOSED: usize = 0b1000;
-const SEND: usize   = 0b0100;
-const RECV: usize   = 0b0010;
-const READY: usize  = 0b0001;
+const CLOSED: u8 = 0b1000;
+const SEND:   u8 = 0b0100;
+const RECV:   u8 = 0b0010;
+const READY:  u8 = 0b0001;
 
 impl<T> Inner<T> {
     #[inline(always)]
     pub(crate) fn new() -> Self {
         Inner {
-            state: AtomicUsize::new(0),
-            value: UnsafeCell::new(MaybeUninit::uninit()),
-            send: UnsafeCell::new(MaybeUninit::uninit()),
-            recv: UnsafeCell::new(MaybeUninit::uninit()),
+            state:    AtomicU8::new(0),
+            value:    UnsafeCell::new(MaybeUninit::uninit()),
+            sender:   UnsafeCell::new(MaybeUninit::uninit()),
+            receiver: UnsafeCell::new(MaybeUninit::uninit()),
         }
     }
 
     // Gets the current state
     #[inline(always)]
-    pub(crate) fn state(&self) -> State { State(self.state.load(Acquire)) }
+    pub(crate) fn state(&self) -> State<T> {
+        self.make_state(self.state.load(Acquire))
+    }
 
-    // Gets the receiver's waker. You *must* check the state to ensure
-    // it is set. This would be unsafe if it were public.
+    // Gets the receiver's waker.
     #[inline(always)]
-    pub(crate) fn recv(&self) -> &Waker { // MUST BE SET
-        debug_assert!(self.state().recv());
-        unsafe { &*(*self.recv.get()).as_ptr() }
+    pub(crate) fn receiver_waker(&self, proof: HasReceiverWaker<T>) -> &Waker {
+        proof.check(self as *const Inner<T>);
+        unsafe { &*(*self.receiver.get()).as_ptr() }
     }
 
     // Sets the receiver's waker.
     #[inline(always)]
-    pub(crate) fn set_recv(&self, waker: Waker) -> State {
-        let recv = self.recv.get();
-        unsafe { (*recv).as_mut_ptr().write(waker) } // !
-        State(self.state.fetch_or(RECV, AcqRel))
+    pub(crate) fn set_receiver_waker(&self, waker: Waker) -> State<T> {
+        let recv = self.receiver.get();
+        // safe because we are only writing it.
+        unsafe { (*recv).as_mut_ptr().write(waker) }
+        self.make_state(self.state.fetch_or(RECV, AcqRel))
     }
 
-    // Gets the sender's waker. You *must* check the state to ensure
-    // it is set. This would be unsafe if it were public.
+    // Gets the sender's waker.
     #[inline(always)]
-    pub(crate) fn send(&self) -> &Waker {
-        debug_assert!(self.state().send());
-        unsafe { &*(*self.send.get()).as_ptr() }
+    pub(crate) fn sender_waker(&self, proof: HasSenderWaker<T>) -> &Waker {
+        proof.check(self as *const Inner<T>);
+        // debug_assert!(self.state().has_sender_waker().is_some());
+        unsafe { &*(*self.sender.get()).as_ptr() }
     }
 
     // Sets the sender's waker.
     #[inline(always)]
-    pub(crate) fn set_send(&self, waker: Waker) -> State {
-        let send = self.send.get();
-        unsafe { (*send).as_mut_ptr().write(waker) } // !
-        State(self.state.fetch_or(SEND, AcqRel))
+    pub(crate) fn set_sender_waker(&self, waker: Waker) -> State<T> {
+        let send = self.sender.get();
+        // safe because we are only writing it.
+        unsafe { (*send).as_mut_ptr().write(waker) }
+        self.make_state(self.state.fetch_or(SEND, AcqRel))
     }
 
     #[inline(always)]
-    pub(crate) fn take_value(&self) -> T { // MUST BE SET
-        debug_assert!(self.state().ready());
+    pub(crate) fn take_value(&self, proof: IsReady<T>) -> T {
+        proof.check(self as *const Inner<T>);
         unsafe { (*self.value.get()).as_ptr().read() }
     }
 
     #[inline(always)]
-    pub(crate) fn set_value(&self, value: T) -> State {
-        debug_assert!(!self.state().ready());
-        let val = self.value.get();
-        unsafe { (*val).as_mut_ptr().write(value) }
-        State(self.state.fetch_or(READY, AcqRel))
+    pub(crate) unsafe fn unsafe_take_value(&self) -> T {
+        debug_assert!(self.state().ready());
+        (*self.value.get()).as_ptr().read()
     }
 
     #[inline(always)]
-    pub(crate) fn close(&self) -> State {
-        State(self.state.fetch_or(CLOSED, AcqRel))
+    pub(crate) fn set_value(&self, value: T) -> State<T> {
+        debug_assert!(!self.state().ready());
+        let val = self.value.get();
+        unsafe { (*val).as_mut_ptr().write(value) }
+        self.make_state(self.state.fetch_or(READY, AcqRel))
+    }
+
+    #[inline(always)]
+    pub(crate) fn close(&self) -> State<T> {
+        self.make_state(self.state.fetch_or(CLOSED, AcqRel))
+    }
+
+    #[cfg(debug_assertions)]
+    #[inline(always)]
+    fn make_state(&self, value: u8) -> State<T> {
+        State(value, self as *const Inner<T>)
+    }
+
+    #[cfg(not(debug_assertions))]
+    #[inline(always)]
+    fn make_state(&self, value: u8) -> State<T> {
+        State(value, PhantomData)
     }
 }
 
 impl<T> Drop for Inner<T> {
     #[inline(always)]
     fn drop(&mut self) {
-        let state = State(*self.state.get_mut());
+        let st = { *self.state.get_mut() as u8 };
+        let state = self.make_state(st);
         // Drop the wakers if they are present
-        if state.recv() {
-            unsafe { drop_in_place((&mut *self.recv.get()).as_mut_ptr()); }
+        if let Some(proof) = state.has_receiver_waker() {
+            proof.check(self as *const Inner<T>);
+            unsafe { drop_in_place((&mut *self.receiver.get()).as_mut_ptr()); }
         }
-        if state.send() {
-            unsafe { drop_in_place((&mut *self.send.get()).as_mut_ptr()); }
+        if let Some(proof) = state.has_sender_waker() {
+            proof.check(self as *const Inner<T>);
+            unsafe { drop_in_place(
+                (&mut *self.sender.get()).as_mut_ptr()
+            ); }
         }
     }
 }
@@ -104,10 +131,72 @@ impl<T> Drop for Inner<T> {
 unsafe impl<T: Send> Send for Inner<T> {}
 unsafe impl<T: Sync> Sync for Inner<T> {}
 
-#[derive(Clone, Copy)]
-pub(crate) struct State(usize);
+#[cfg(not(debug_assertions))]
+pub(crate) struct State<T>(u8, PhantomData<T>);
 
-impl State {
+#[cfg(debug_assertions)]
+pub(crate) struct State<T>(u8, *const Inner<T>);
+
+
+#[cfg(debug_assertions)]
+macro_rules! proof {
+    ($name:ident) => {
+        pub(crate) struct $name<T>(*const Inner<T>);
+        impl<T> $name<T> {
+            pub(crate) fn check(self, other: *const Inner<T>) {
+                debug_assert!(self.0 ==other);
+            }
+        }
+    }
+}
+
+#[cfg(not(debug_assertions))]
+macro_rules! proof {
+    ($name:ident) => {
+        pub(crate) struct $name<T>(PhantomData<T>);
+        impl<T> $name<T> {
+            #[inline(always)]
+            pub(crate) fn check(self, _other: *const Inner<T>) {}
+        }
+    }
+}
+
+proof!(IsOpen);
+proof!(IsClosed);
+proof!(IsReady);
+proof!(IsNotReady);
+proof!(HasReceiverWaker);
+proof!(HasSenderWaker);
+
+impl<T> State<T> {
+    #[inline(always)]
+    pub(crate) fn is_open(&self) -> Result<IsOpen<T>, IsClosed<T>> {
+        #[cfg(debug_assertions)]
+        if self.closed() { Err(IsClosed(self.1)) } else { Ok(IsOpen(self.1)) }
+        #[cfg(not(debug_assertions))]
+        if self.closed() { Err(IsClosed(PhantomData)) } else { Ok(IsOpen(PhantomData)) }
+    }
+    #[inline(always)]
+    pub(crate) fn is_ready(&self) -> Result<IsReady<T>, IsNotReady<T>> {
+        #[cfg(debug_assertions)]
+        if self.ready() { Ok(IsReady(self.1)) } else { Err(IsNotReady(self.1)) }
+        #[cfg(not(debug_assertions))]
+        if self.ready() { Ok(IsReady(PhantomData)) } else { Err(IsNotReady(PhantomData)) }
+    }
+    #[inline(always)]
+    pub(crate) fn has_receiver_waker(&self) -> Option<HasReceiverWaker<T>> {
+        #[cfg(debug_assertions)]
+        if self.recv() { Some(HasReceiverWaker(self.1))} else { None }
+        #[cfg(not(debug_assertions))]
+        if self.recv() { Some(HasReceiverWaker(PhantomData))} else { None }
+    }
+    #[inline(always)]
+    pub(crate) fn has_sender_waker(&self) -> Option<HasSenderWaker<T>> {
+        #[cfg(debug_assertions)]
+        if self.send() { Some(HasSenderWaker(self.1)) } else { None }
+        #[cfg(not(debug_assertions))]
+        if self.send() { Some(HasSenderWaker(PhantomData)) } else { None }
+    }
     #[inline(always)]
     pub(crate) fn closed(&self) -> bool { (self.0 & CLOSED) == CLOSED }
     #[inline(always)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,13 +26,13 @@ pub fn oneshot<T>() -> (Sender<T>, Receiver<T>) {
 
 /// An empty struct that signifies the channel is closed.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct Closed();
+pub struct Closed;
 
 /// We couldn't receive a message.
 #[derive(Debug)]
-pub enum TryRecvError<T> {
+pub enum TryRecvError {
     /// The Sender didn't send us a message yet.
-    Empty(Receiver<T>),
+    Empty,
     /// The Sender has dropped.
     Closed,
 }

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -6,6 +6,7 @@ use core::task::{Context, Poll};
 #[derive(Debug)]
 pub struct Receiver<T> {
     inner: Arc<Inner<T>>,
+    // Set when the value has been received or the channel has been closed.
     done: bool,
 }
 
@@ -19,29 +20,57 @@ impl<T> Receiver<T> {
     #[inline(always)]
     pub fn close(self) { }
 
+    /// true if the channel is closed
     #[inline(always)]
-    fn handle_state(&mut self, state: crate::inner::State) -> Poll<Result<T, Closed>> {
-        if state.ready() {
-            Poll::Ready(Ok(self.inner.take_value()))
-        } else if state.closed() {
-            Poll::Ready(Err(Closed()))
-        } else {
-            Poll::Pending
-        }.map(|x| {
-            self.done = true;
-            x
-        })
+    pub fn is_closed(&self) -> bool { self.inner.state().closed() }
+
+    #[inline(always)]
+    fn handle_state(&mut self, state: &crate::inner::State<T>) -> Poll<Result<T, Closed>> {
+        match state.is_ready() {
+            // If the value is ready, we are safe to take it because
+            // the sender never untakes it and we haven't yet taken it
+            // (or done would be set and we checked in the caller).
+            Ok(proof) => {
+                self.done = true;
+                Poll::Ready(Ok(self.inner.take_value(proof)))
+            }
+            Err(proof) => {
+                proof.check(&*self.inner as *const Inner<T>);
+                match state.is_open() {
+                    // Because we might be either sync or async here,
+                    // we can't do anything.
+                    Ok(proof) => {
+                        proof.check(&*self.inner as *const Inner<T>);
+                        Poll::Pending
+                    }
+                    // If the channel is closed, the Sender has done
+                    // it because we haven't yet taken it (or done
+                    // would be set and we checked in the caller).
+                    Err(proof) => {
+                        proof.check(&*self.inner as *const Inner<T>);
+                        self.done = true;
+                        Poll::Ready(Err(Closed))
+                    }
+                }
+            }
+        }
     }
 
-    /// Attempts to receive. On failure, if the channel is not closed,
-    /// returns self to try again.
+    /// Attempts to receive the value.
     #[inline]
-    pub fn try_recv(mut self) -> Result<T, TryRecvError<T>> {
-        let state = self.inner.state();
-        match self.handle_state(state) {
-            Poll::Ready(Ok(x)) => Ok(x),
-            Poll::Ready(Err(Closed())) => Err(TryRecvError::Closed),
-            Poll::Pending => Err(TryRecvError::Empty(self)),
+    pub fn try_recv(&mut self) -> Result<T, TryRecvError> {
+        if self.done {
+            // The channel has either been closed or we've already
+            // received a value, which we'll count as closed. Either
+            // way, we won't be receiving anything on it now.
+            Err(TryRecvError::Closed)
+        } else {
+            let state = self.inner.state();
+            match self.handle_state(&state) {
+                Poll::Ready(Ok(x)) => Ok(x),
+                Poll::Ready(Err(Closed)) => Err(TryRecvError::Closed),
+                Poll::Pending => Err(TryRecvError::Empty),
+            }
         }
     }
 }
@@ -50,17 +79,27 @@ impl<T> Future for Receiver<T> {
     type Output = Result<T, Closed>;
     fn poll(self: Pin<&mut Self>, ctx: &mut Context) -> Poll<Result<T, Closed>> {
         let this = Pin::into_inner(self);
-        match this.handle_state(this.inner.state()) {
-            Poll::Pending => {},
-            x => return x,
+        if this.done {
+            // The channel has either been closed or we've already
+            // received a value, which we'll count as closed. Either
+            // way, we won't be receiving anything on it now.
+            Poll::Ready(Err(Closed))
+        } else {
+            let state = this.inner.state();
+            match this.handle_state(&state) {
+                Poll::Pending => {},
+                x => return x,
+            }
+            let state = this.inner.set_receiver_waker(ctx.waker().clone());
+            match this.handle_state(&state) {
+                Poll::Pending => {},
+                x => return x,
+            }
+            if let Some(proof) = state.has_sender_waker() {
+                this.inner.sender_waker(proof).wake_by_ref();
+            }
+            Poll::Pending
         }
-        let state = this.inner.set_recv(ctx.waker().clone());
-        match this.handle_state(state) {
-            Poll::Pending => {},
-            x => return x,
-        }
-        if state.send() { this.inner.send().wake_by_ref(); }
-        Poll::Pending
     }
 }
 
@@ -69,9 +108,27 @@ impl<T> Drop for Receiver<T> {
     fn drop(&mut self) {
         if !self.done {
             let state = self.inner.state();
-            if !state.closed() && !state.ready() {
-                let old = self.inner.close();
-                if old.send() { self.inner.send().wake_by_ref(); }
+            match (state.is_open(), state.is_ready()) {
+                (Ok(p),Ok(q)) => {
+                    p.check(&*self.inner as *const Inner<T>);
+                    q.check(&*self.inner as *const Inner<T>);
+                }
+                (Ok(p),Err(q)) => {
+                    p.check(&*self.inner as *const Inner<T>);
+                    q.check(&*self.inner as *const Inner<T>);
+                    let old = self.inner.close();
+                    if let Some(r) = old.has_sender_waker() {
+                        self.inner.sender_waker(r).wake_by_ref();
+                    }
+                }
+                (Err(p),Ok(q)) => {
+                    p.check(&*self.inner as *const Inner<T>);
+                    q.check(&*self.inner as *const Inner<T>);
+                }
+                (Err(p),Err(q)) => {
+                    p.check(&*self.inner as *const Inner<T>);
+                    q.check(&*self.inner as *const Inner<T>);
+                }
             }
         }
     }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -33,14 +33,14 @@ fn recv_recv() {
 fn close_recv() {
     let (s,r) = oneshot::<i32>();
     s.close();
-    assert_eq!(Err(Closed()), block_on(r));
+    assert_eq!(Err(Closed), block_on(r));
 }
 
 #[test]
 fn close_send() {
     let (mut s,r) = oneshot::<bool>();
     r.close();
-    assert_eq!(Err(Closed()), s.send(true));
+    assert_eq!(Err(Closed), s.send(true));
 }
 
 #[test]
@@ -55,7 +55,7 @@ fn recv_close() {
     let (s,r) = oneshot::<bool>();
     assert_eq!(
         block_on(zip!(r, async { s.close() })),
-        (Err(Closed()), ())
+        (Err(Closed), ())
     )
 }
 
@@ -67,7 +67,7 @@ fn wait_close() {
             zip!(async { s.wait().await.unwrap_err() },
                  async { r.close() })
         ),
-        (Closed(), ())
+        (Closed, ())
     )
 }
 
@@ -89,7 +89,7 @@ fn wait_recv_close() {
         block_on(
             zip!(async { s.wait().await.unwrap().close(); println!("closed"); }, r)
         ),
-        ((), Err(Closed()))
+        ((), Err(Closed))
     )
 }
 
@@ -108,5 +108,5 @@ fn wait_recv_send() {
 fn close_wait() {
     let (s,r) = oneshot::<bool>();
     r.close();
-    assert_eq!(Closed(), block_on(s.wait()).unwrap_err());
+    assert_eq!(Closed, block_on(s.wait()).unwrap_err());
 }


### PR DESCRIPTION
This is an experimental rewrite that uses proof objects to make me feel more confident that it's harder to accidentally mess up the correctness of the core logic.

It also includes detailed documentation of the workings of sender and receiver work. In the event we choose not to go down this path, I will backport these and any changes i made while going through and making them.

Now, here is where things get interesting: benchmarks have broadly speaking gotten *better*. The major performance regressions seem to be:

* send/success is now about 16.5ns whereas the benches in the README have it at about 10ns. i cannot get close to that number on any version where the criterion benches were actually committed, which means it was probably benched in my secret async repo. further digging will be required to figure out what's going on here, but i suspect that version may  have been fast at the expense of correctness. Otherwise it could be related to no longer taking ownership of `self` in `send`.
* try_recv/empty is now about 17-18ns from about 11-12ns in 0.5.0. it looks like rust doesn't have a good time with the proof objects in a `Result`.

overall, quite happy that i've proved the concept, and i'm quite surprised by the way this *improves* performance of a number of benches. although this could be that i spotted a few bugs while i was documenting. who knows?

sooo... please let me know your thoughts.